### PR TITLE
Pin jsonschema version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bumpversion
-jsonschema==3.0.1
+jsonschema==3.0.2
 pytest==3.9.2
 pytest-asyncio==0.9.0
 pytest-cov==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license='MIT',
     python_requires='>=3.5.2,<4',
     install_requires=[
-        'jsonschema==3.0.1'
+        'jsonschema==3.0.2'
     ],
     include_package_data=True,
     packages=find_packages('src'),

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license='MIT',
     python_requires='>=3.5.2,<4',
     install_requires=[
-        'jsonschema'
+        'jsonschema==3.0.1'
     ],
     include_package_data=True,
     packages=find_packages('src'),


### PR DESCRIPTION
This is a workaround for issues with the ref resolver not using a uri. 

The real fix for this is to move away from json schemas, and move towards using dataclasses, instead.