### PR TITLE
Temporarily disable validations when creating objects without args

### DIFF
--- a/src/polyswarmartifact/schema/bounty.py
+++ b/src/polyswarmartifact/schema/bounty.py
@@ -8,13 +8,13 @@ from pydantic import (
     validator,
 )
 
-from .schema import MD5, SHA1, SHA256, Schema, Missing
+from .schema import MD5, SHA1, SHA256, Schema
 
 
 class FileArtifact(Schema):
     filename: Optional[str]
     filesize: Optional[PositiveInt]
-    mimetype: StrictStr = Missing
+    mimetype: StrictStr = ...
     sha256: Optional[SHA256] = Field(title='SHA256')
     sha1: Optional[SHA1] = Field(title='SHA1')
     md5: Optional[MD5] = Field(title='MD5')
@@ -24,7 +24,7 @@ class URLArtifact(Schema):
     # protocol can actually be derived directly from `uri`, we keep it here to preserve a
     # preexisting interface.
     protocol: Optional[str]
-    uri: AnyUrl = Missing
+    uri: AnyUrl = ...
 
     def __post_init__(self):
         if self.protocol is None:

--- a/src/polyswarmartifact/schema/verdict.py
+++ b/src/polyswarmartifact/schema/verdict.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from pydantic import Field, IPvAnyAddress, StrictStr
 
-from .schema import Domain, Missing, Schema, VersionStr, chainable
+from .schema import Domain, Schema, VersionStr, chainable
 
 
 class Scanner(Schema):
@@ -30,7 +30,8 @@ class StixSignature(Schema):
 
 class Verdict(Schema):
     malware_family: StrictStr = Field(
-        default=Missing, description='name of the malware family specified by this microengine'
+        default=...,
+        description='name of the malware family specified by this microengine',
     )
     domains: Optional[List[Domain]] = []
     ip_addresses: Optional[List[IPvAnyAddress]] = []


### PR DESCRIPTION
This commit also removes the previous "missing" hack of setting values which cannot be missing to a default value which cannot be validated. This PR removes that and simply disables validations when an object is instantiated without any arguments.