### PR TITLE
Update linting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 1.4.0
-commit = True
-tag = False
-
-[bumpversion:file:src/polyswarmartifact/__init__.py]
-
-[bumpversion:file:setup.py]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: help clean lint format test
+.DEFAULT_GOAL := help
+SRCDIR := src/polyswarmartifact/
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+	  target, help = match.groups()
+	  print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: ## remove build artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+	rm -fr .pytest_cache/
+	find . \( -path ./env -o -path ./venv -o -path ./.env -o -path ./.venv \) -prune -o -name '*.egg-info' -exec rm -fr {} +
+	find . \( -path ./env -o -path ./venv -o -path ./.env -o -path ./.venv \) -prune -o -name '*.egg' -exec rm -f {} +
+
+lint: ## check style
+	-mypy
+	-flake8 $(SRCDIR) tests
+	-yapf -p -r -d $(SRCDIR)
+	-isort --recursive --diff $(SRCDIR)
+
+format:  ## format code in Polyswarm style
+	yapf -p -r -i $(SRCDIR) tests
+	isort --recursive $(SRCDIR) tests
+
+test: ## run tests
+	py.test

--- a/README.md
+++ b/README.md
@@ -18,36 +18,27 @@ Since we cannot remove fields, when a field is no longer useful, it needs to be 
 Unfortunately we cannot add nullable at a later date, as that would invalidate new schemas when being read by an old  
 
 We can easily remove required fields, but we cannot add more. 
-Doing so would invalidated old schemas.  
+Doing so would invalidated old schemas.
 
 ## Schema object
 
-Schema objects possess the following methods and attributes:
+Descendants of the `Schema` class also inherit this methods & attributes:
 
-``dict()``
+- ``dict()``
     returns a dictionary of the model's fields and values
-``json()``
+- ``json()``
     returns a JSON string representation dict()
-``copy()``
+- ``copy()``
     returns a deep copy of the model
-``parse_obj()``
+- ``parse_obj()``
     a utility for loading any object into a model with error handling if the object is not a dictionary
-``parse_raw()``
-    a utility for loading strings of numerous formats
-``parse_file()``
-    like parse_raw() but for files
-``from_orm()``
-    loads data into a model from an arbitrary class
-``schema()``
+- ``schema()``
     returns a dictionary representing the model as JSON Schema
-``schema_json()``
+- ``schema_json()``
     returns a JSON string representation of schema()
-``construct()``
-    a class method for creating models without running validation
-``__fields_set__``
+- ``__fields_set__``
     Set of names of fields which were set when the model instance was initialised
-``__fields__``
+- ``__fields__``
     a dictionary of the model's fields
-``__config__``
+- ``__config__``
     the configuration class for the model
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bumpversion
+bump2version
 pydantic==1.5.1
 pytest==5.4.1
 pytest-runner==5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = True
 tag = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,15 @@
-[aliases]
-test=pytest
+[bumpversion]
+current_version = 1.4.0
+commit = True
+tag = False
 
-[coverage:run]
-source =
-	src
-omit =
-	env/*
-	venv/*
-	.env/*
-	.venv/*
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
 
-[tool:pytest]
-norecursedirs =
-	env
-	venv
-	.env
-	.venv
-collect_ignore = ['setup.py']
+[bumpversion:file:src/polyswarmartifact/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
 
 [isort]
 atomic = True
@@ -30,14 +23,8 @@ multi_line_output = 3
 use_parentheses = True
 
 [flake8]
+exclude = docs
 max-line-length = 119
-exclude =
-        env
-        .env
-        .venv
-        venv
-        docs
-        *.egg_info
 ignore = E402,  # module imports not at top of file
 	E266,  # Too many leading '#' in comment
 	E402,  # module imports not at top of file
@@ -50,13 +37,11 @@ ignore = E402,  # module imports not at top of file
 	W503,  # line break before binary operator
 	W504,  # line break after binary operator
 	E266,  # missing whitespace around arithmetic operators
-  E213,  # Don't require `cls' / `self' as first argument of class / instance method
 
 [mypy]
 cache_dir = .mypy_cache
 check_untyped_defs = True
 files = src/polyswarmartifact
-mypy_path = stubshed
 ignore_missing_imports = True
 incremental = True
 pretty = True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-artifact',
-    version='1.4.0',
+    version='1.5.0',
     description='Library containing artifact type enums and functions',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarmartifact/__init__.py
+++ b/src/polyswarmartifact/__init__.py
@@ -1,4 +1,4 @@
 from .artifact_type import ArtifactType
 from .exceptions import PolyswarmArtifactException, DecodeError
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/src/polyswarmartifact/artifact_type.py
+++ b/src/polyswarmartifact/artifact_type.py
@@ -1,5 +1,5 @@
-import logging
 from enum import Enum
+import logging
 
 from .exceptions import DecodeError
 

--- a/src/polyswarmartifact/schema/assertion.py
+++ b/src/polyswarmartifact/schema/assertion.py
@@ -2,11 +2,11 @@ from typing import List
 
 from pydantic import Field
 
-from .schema import Schema, chainable
+from .schema import CollectionSchema, chainable
 from .verdict import Verdict
 
 
-class Assertion(Schema):
+class Assertion(CollectionSchema):
     __root__: List[Verdict] = Field(min_items=1, max_items=256, default=[])
 
     @property
@@ -20,9 +20,3 @@ class Assertion(Schema):
     @chainable
     def add_artifacts(self, verdicts: List[Verdict]):
         self.__root__.extend(verdicts)
-
-    def __iter__(self):
-        return iter(self.__root__)
-
-    def __getitem__(self, item):
-        return self.__root__[item]

--- a/src/polyswarmartifact/schema/bounty.py
+++ b/src/polyswarmartifact/schema/bounty.py
@@ -1,14 +1,8 @@
 from typing import List, Optional, Union
 
-from pydantic import (
-    AnyUrl,
-    Field,
-    PositiveInt,
-    StrictStr,
-    validator,
-)
+from pydantic import AnyUrl, Field, PositiveInt, StrictStr, validator
 
-from .schema import MD5, SHA1, SHA256, Schema
+from .schema import MD5, SHA1, SHA256, CollectionSchema, Schema
 
 
 class FileArtifact(Schema):
@@ -18,6 +12,9 @@ class FileArtifact(Schema):
     sha256: Optional[SHA256] = Field(title='SHA256')
     sha1: Optional[SHA1] = Field(title='SHA1')
     md5: Optional[MD5] = Field(title='MD5')
+
+    class Config:
+        extra = 'allow'
 
 
 class URLArtifact(Schema):
@@ -30,8 +27,11 @@ class URLArtifact(Schema):
         if self.protocol is None:
             self.protocol = self.uri.protocol
 
+    class Config:
+        extra = 'allow'
 
-class Bounty(Schema):
+
+class Bounty(CollectionSchema):
     __root__: List[Union[FileArtifact, URLArtifact]] = Field(min_items=1, max_items=256, default=[])
 
     @property
@@ -50,9 +50,3 @@ class Bounty(Schema):
             uri = '{}://{}'.format(proto, next(reversed(uri.split('://', 1))))
         self.__root__.append(URLArtifact(uri=str(uri), protocol=protocol))
         return self
-
-    def __iter__(self):
-        return iter(self.__root__)
-
-    def __getitem__(self, item):
-        return self.__root__[item]

--- a/src/polyswarmartifact/schema/schema.py
+++ b/src/polyswarmartifact/schema/schema.py
@@ -108,8 +108,24 @@ class Schema(BaseModel):
 
 
 class CollectionSchema(Schema):
+    """Schema for objects which are collections of other types"""
+    def __len__(self):
+        return len(self.__root__)
+
     def __iter__(self):
         return iter(self.__root__)
 
+    def __contains__(self, o):
+        return o in self.__root__
+
     def __getitem__(self, item):
         return self.__root__[item]
+
+    def __iadd__(self, os):
+        return self.__root__.__iadd__(os)
+
+    def append(self, o):
+        return self.__root__.append(o)
+
+    def extend(self, os):
+        return self.__root__.extend(os)

--- a/src/polyswarmartifact/schema/verdict.py
+++ b/src/polyswarmartifact/schema/verdict.py
@@ -14,6 +14,9 @@ class Scanner(Schema):
     signatures_version: Optional[str] = Field(description="version of the engine's antimalware signatures")
     environment: Optional[Dict[str, Any]] = Field(description="analysis environment metadata")
 
+    class Config:
+        extra = 'allow'
+
 
 class StixSignature(Schema):
     stix_schema: str = Field(alias='schema')
@@ -26,6 +29,9 @@ class StixSignature(Schema):
     def dict(self, **kwargs):
         kwargs['by_alias'] = True
         return super().dict(**kwargs)
+
+    class Config:
+        extra = 'allow'
 
 
 class Verdict(Schema):
@@ -83,8 +89,7 @@ class Verdict(Schema):
 
     @chainable
     def set_analysis_conclusion(self, heuristic: bool = None):
-        if heuristic is not None:
-            self.heuristic = heuristic
+        self.heuristic = heuristic
 
     def set_scanner(self, **scanner):
         environment = {k: scanner.pop(k, None) for k in ('architecture', 'operating_system')}

--- a/tests/test_artifact_type.py
+++ b/tests/test_artifact_type.py
@@ -1,4 +1,5 @@
 import pytest
+
 from polyswarmartifact import ArtifactType
 from polyswarmartifact.exceptions import DecodeError
 

--- a/tests/test_assertion_schema.py
+++ b/tests/test_assertion_schema.py
@@ -1,17 +1,16 @@
 import json
 
 import pytest
+
 from polyswarmartifact.schema.assertion import Assertion
 from polyswarmartifact.schema.verdict import Verdict
 
 
 def test_valid_blob_validates_true():
     # arrange
-    blob = [
-        {
-            "malware_family": "Eicar",
-        }
-    ]
+    blob = [{
+        "malware_family": "Eicar",
+    }]
     # act
     result = Assertion.validate(blob)
     # assert
@@ -20,11 +19,9 @@ def test_valid_blob_validates_true():
 
 def test_invalid_scanner_validates_false():
     # arrange
-    blob = [
-        {
-            "malware_familty": None,
-        }
-    ]
+    blob = [{
+        "malware_familty": None,
+    }]
     # act
     result = Assertion.validate(blob)
     # assert

--- a/tests/test_bounty_schema.py
+++ b/tests/test_bounty_schema.py
@@ -1,16 +1,15 @@
 import json
 
 import pytest
+
 from polyswarmartifact.schema.bounty import Bounty
 
 
 def test_valid_blob_validates_true():
     # arrange
-    blob = [
-        {
-            "mimetype": "text/plain",
-        }
-    ]
+    blob = [{
+        "mimetype": "text/plain",
+    }]
     # act
     result = Bounty.validate(blob)
     # assert
@@ -19,11 +18,9 @@ def test_valid_blob_validates_true():
 
 def test_invalid_scanner_validates_false():
     # arrange
-    blob = [
-        {
-            "filesize": "1",
-        }
-    ]
+    blob = [{
+        "filesize": "1",
+    }]
     # act
     result = Bounty.validate(blob)
     # assert
@@ -33,9 +30,7 @@ def test_invalid_scanner_validates_false():
 def test_add_file_artifact():
     # arrange
     bounty = Bounty()
-    artifact = {
-        "mimetype": "text/plain"
-    }
+    artifact = {"mimetype": "text/plain"}
     # act
     bounty.add_file_artifact(mimetype="text/plain")
     # assert
@@ -45,10 +40,7 @@ def test_add_file_artifact():
 def test_add_url_artifact():
     # arrange
     bounty = Bounty()
-    artifact = {
-        "protocol": "https://",
-        "uri": 'https://google.com'
-    }
+    artifact = {"protocol": "https://", "uri": 'https://google.com'}
     # act
     bounty.add_url_artifact(protocol="https://", uri='google.com')
     # assert
@@ -68,6 +60,7 @@ def test_add_both_artifact():
     with pytest.raises(ValueError):
         bounty.json()
 
+
 def test_add_both_artifact_new():
     # arrange
     bounty = Bounty()
@@ -78,7 +71,6 @@ def test_add_both_artifact_new():
         bounty.add_file_artifact(mimetype="test")
         # assert
         bounty.json()
-
 
 
 def test_add_full_artifact():
@@ -93,10 +85,14 @@ def test_add_full_artifact():
         'md5': "772ac1a55fab1122f3b369ee9cd31549"
     }
     # act
-    bounty.add_file_artifact(mimetype="text/plain", filename="file", filesize=1,
-                                 sha256="74b4147957813b62cc8987f2b711ddb31f8cb46dcbf71502033da66053c8780a",
-                                 sha1="f013d66c7f6817d08b7eb2a93e6d0440c1f3e7f8",
-                                 md5="772ac1a55fab1122f3b369ee9cd31549")
+    bounty.add_file_artifact(
+        mimetype="text/plain",
+        filename="file",
+        filesize=1,
+        sha256="74b4147957813b62cc8987f2b711ddb31f8cb46dcbf71502033da66053c8780a",
+        sha1="f013d66c7f6817d08b7eb2a93e6d0440c1f3e7f8",
+        md5="772ac1a55fab1122f3b369ee9cd31549"
+    )
     # assert
     assert bounty.artifacts and bounty.artifacts[0].dict() == artifact
 
@@ -142,11 +138,13 @@ def test_builder_256_scanners_is_valid():
     bounty = Bounty()
     # act
     for i in range(1, 256):
-        bounty.add_file_artifact(mimetype="text/plain",
-                                 filename="file",
-                                 filesize=str(i),
-                                 sha256="74b4147957813b62cc8987f2b711ddb31f8cb46dcbf71502033da66053c8780a",
-                                 sha1="f013d66c7f6817d08b7eb2a93e6d0440c1f3e7f8",
-                                 md5="772ac1a55fab1122f3b369ee9cd31549",)
+        bounty.add_file_artifact(
+            mimetype="text/plain",
+            filename="file",
+            filesize=str(i),
+            sha256="74b4147957813b62cc8987f2b711ddb31f8cb46dcbf71502033da66053c8780a",
+            sha1="f013d66c7f6817d08b7eb2a93e6d0440c1f3e7f8",
+            md5="772ac1a55fab1122f3b369ee9cd31549",
+        )
     # assert
     assert Bounty.validate(bounty.dict())

--- a/tests/test_schema_generation.py
+++ b/tests/test_schema_generation.py
@@ -1,0 +1,12 @@
+import pprint
+
+import pytest
+
+from polyswarmartifact.schema import Assertion, Bounty, Verdict, FileArtifact, URLArtifact
+
+
+@pytest.mark.parametrize('klass', [Assertion, Bounty, Verdict, FileArtifact, URLArtifact])
+def test_schema_generation(klass):
+    schema = klass.schema()
+    assert isinstance(schema, dict)
+    assert schema == klass.get_schema()


### PR DESCRIPTION
Add project-standard `Makefile` and `setup.cfg` for linting the codebase & consolidates `bumpversion.cfg` into `setup.cfg`.

This PR also contains a commit which removes some of the unnessasary conversion functions in `Schema` and creates a `CollectionSchema` class which can be inherited from in `Schema`-objects which are collections of other types.