### PR TITLE
Add metadata class ScanMetadata

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.2
+current_version = 1.4.3
 commit = True
 tag = False
 sign_tags = True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='polyswarm-artifact',
-    version='1.4.2',
+    version='1.4.3',
     description='Library containing artifact type enums and functions',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/polyswarmartifact/__init__.py
+++ b/src/polyswarmartifact/__init__.py
@@ -1,4 +1,4 @@
 from .artifact_type import ArtifactType
 from .exceptions import PolyswarmArtifactException, DecodeError
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'

--- a/src/polyswarmartifact/schema/__init__.py
+++ b/src/polyswarmartifact/schema/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     'Bounty',
     'Schema',
     'Verdict',
+    'ScanMetadata',
     'FileArtifact',
     'URLArtifact',
     'Scanner',

--- a/src/polyswarmartifact/schema/__init__.py
+++ b/src/polyswarmartifact/schema/__init__.py
@@ -1,7 +1,7 @@
 from .schema import Schema
 from .assertion import Assertion
 from .bounty import Bounty, FileArtifact, URLArtifact
-from .verdict import Verdict, Scanner, StixSignature
+from .verdict import Verdict, Scanner, StixSignature, ScanMetadata
 
 __all__ = [
     'Assertion',

--- a/src/polyswarmartifact/schema/verdict.py
+++ b/src/polyswarmartifact/schema/verdict.py
@@ -28,7 +28,7 @@ class StixSignature(Schema):
         return super().dict(**kwargs)
 
 
-class Verdict(Schema):
+class ScanMetadata(Schema):
     malware_family: StrictStr = Field(
         default=...,
         description='name of the malware family specified by this microengine',
@@ -95,3 +95,7 @@ class Verdict(Schema):
 
     class Config:
         extra = 'allow'
+
+
+class Verdict(ScanMetadata):
+    pass


### PR DESCRIPTION
Solves the conflict with microengine-webhooks-py which has a Verdict Enum. 