### PR TITLE
[FIX] Pydantic v2 behavior fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ dev-pypi:
   script:
     - bump-my-version bump --no-commit --no-tag dev
     - python -m build
-    - twine upload --skip-existing --disable-progress-bar --non-interactive dist/*
+    - twine upload --disable-progress-bar --non-interactive dist/*
 
 ###############################################################
 # Test Stage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ dev-pypi:
     - stage-kube-newer
   stage: build
   before_script:
-    - pip3 install -q --upgrade pip build twine bump-my-version
+    - pip3 install -q --upgrade pip build twine bump-my-version "click<8.3"
   script:
     - bump-my-version bump --no-commit --no-tag dev
     - python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "polyswarm_artifact"
-version = "2.1.0"
+version = "2.2.0"
 description = "Library containing artifact type enums and functions"
 readme = "README.md"
 authors = [{ name = "PolySwarm Developers", email = "info@polyswarm.io" }]
@@ -47,7 +47,7 @@ include-package-data = true
 where = ["src"]
 
 [tool.bumpversion]
-current_version = "2.1.0"
+current_version = "2.2.0"
 commit = true
 tag = false
 sign_tags = true

--- a/src/polyswarmartifact/__init__.py
+++ b/src/polyswarmartifact/__init__.py
@@ -1,4 +1,4 @@
 from .artifact_type import ArtifactType
 from .exceptions import PolyswarmArtifactException, DecodeError
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/src/polyswarmartifact/schema/schema.py
+++ b/src/polyswarmartifact/schema/schema.py
@@ -118,6 +118,20 @@ class Schema(BaseModel):
     @classmethod
     def model_validate(cls: Type['BaseModel'], value: Any, **kwargs) -> 'Union[Schema, bool]':
         try:
+            return BaseModel.model_validate.__func__(cls, value, **kwargs)
+        except ValidationError as e:
+            logger.error(e)
+            return False
+        return False
+
+    @classmethod
+    def _model_validate_old(cls: Type['BaseModel'], value: Any, **kwargs) -> 'Union[Schema, bool]':
+        """
+        Previous version of model_validate
+
+        Kept to make easier to keep compatibility where needed
+        """
+        try:
             BaseModel.model_validate.__func__(cls, value)
         except ValidationError as e:
             logger.error(e)


### PR DESCRIPTION
Had to update `Schema.model_validate()` to comply with Pydantic v2 expectations.

The previous version was based on Pydantic v1 expectations.
Newer is compatible most of the times, specially when checked
as bool.

If we find something in the future that is hard to adapt, can still change the caller
code to use `Schema._model_validate_old()`, a copy of the previous
implementation.

When everything got ported, `_model_validate_old()` is a pseudoprivate that can be gone.